### PR TITLE
Adding the ability to set sambuilder sort order

### DIFF
--- a/samwell/sam/__init__.py
+++ b/samwell/sam/__init__.py
@@ -117,6 +117,7 @@ Module Contents
 The module contains the following public classes:
 
     - :class:`~samwell.sam.SamFileType` -- Enumeration of valid SAM/BAM/CRAM file types.
+    - :class:`~samwell.sam.SamOrder` -- Enumeration of possible SAM/BAM/CRAM sort orders.
     - :class:`~samwell.sam.CigarOp` -- Enumeration of operators that can appear in a Cigar string.
     - :class:`~samwell.sam.CigarElement` -- Class representing an element in a Cigar string.
     - :class:`~samwell.sam.CigarParsingException` -- The exception raised specific to parsing a
@@ -608,5 +609,11 @@ def set_pair_info(r1: AlignedSegment, r2: AlignedSegment, proper_pair: bool = Tr
 
 @enum.unique
 class SamOrder(enum.Enum):
-    Coordinate = "Coordinate"
-    QueryName = "QueryName"
+    """
+    Enumerations of possible sort orders for a SAM file.
+    """
+
+    Unsorted = "unsorted" #: the SAM / BAM / CRAM is unsorted
+    Coordinate = "coordinate"  #: coordinate sorted
+    QueryName = "queryname"  #: queryname sorted
+    Unknown = "unknown" # Unknown SAM / BAM / CRAM sort order

--- a/samwell/sam/__init__.py
+++ b/samwell/sam/__init__.py
@@ -613,7 +613,7 @@ class SamOrder(enum.Enum):
     Enumerations of possible sort orders for a SAM file.
     """
 
-    Unsorted = "unsorted" #: the SAM / BAM / CRAM is unsorted
+    Unsorted = "unsorted"  #: the SAM / BAM / CRAM is unsorted
     Coordinate = "coordinate"  #: coordinate sorted
     QueryName = "queryname"  #: queryname sorted
-    Unknown = "unknown" # Unknown SAM / BAM / CRAM sort order
+    Unknown = "unknown"  # Unknown SAM / BAM / CRAM sort order

--- a/samwell/sam/__init__.py
+++ b/samwell/sam/__init__.py
@@ -604,3 +604,9 @@ def set_pair_info(r1: AlignedSegment, r2: AlignedSegment, proper_pair: bool = Tr
     insert_size = isize(r1, r2)
     r1.template_length = insert_size
     r2.template_length = - insert_size
+
+
+@enum.unique
+class SamOrder(enum.Enum):
+    Coordinate = "Coordinate"
+    QueryName = "QueryName"

--- a/samwell/sam/sambuilder.py
+++ b/samwell/sam/sambuilder.py
@@ -401,7 +401,8 @@ class SamBuilder:
     def to_path(self,
                 path: Optional[Path] = None,
                 index: bool = True,
-                pred: Callable[[AlignedSegment], bool] = lambda r: True) -> Path:
+                pred: Callable[[AlignedSegment], bool] = lambda r: True,
+                sort_opts: Optional[List[str]] = None) -> Path:
         """Write the accumulated records to a file, sorts & indexes it, and returns the Path.
         If a path is provided, it will be written to, otherwise a temporary file is created
         and returned.
@@ -410,6 +411,7 @@ class SamBuilder:
             path: a path at which to write the file, otherwise a temp file is used.
             index: if True an index is generated, otherwise not.
             pred: optional predicate to specify which reads should be output
+            sort_opts: additional args to pass to samtools sort. E.g. ["-n", "-@", "5"]
 
         Returns:
             Path: The path to the sorted (and possibly indexed) file.
@@ -428,7 +430,9 @@ class SamBuilder:
                     if pred(rec):
                         writer.write(rec)
 
-            pysam.sort("-o", str(path), fp.name)
+            sort_opt_list = ["-o", str(path), fp.name]
+            sort_opt_list = sort_opt_list if sort_opts is None else sort_opts + sort_opt_list
+            pysam.sort(*sort_opt_list)
             if index:
                 pysam.index(str(path))
 

--- a/samwell/sam/sambuilder.py
+++ b/samwell/sam/sambuilder.py
@@ -117,6 +117,9 @@ class SamBuilder:
             extra_header: a dictionary of extra values to add to the header, None otherwise.  See
                           `::class::~pysam.AlignmentHeader` for more details.
             seed: a seed value for random number/string generation
+            sort_order: optional sort order, if none reads will be output in the same order as they
+                were appended. If `SamOrder.Coordinate`, reads will be ordered by reference index
+                and coordinate order. If `SamOrder.QueryName`, reads will be ordered by query name.
         """
 
         self.r1_len: int = r1_len if r1_len is not None else self.DEFAULT_R1_LENGTH

--- a/samwell/sam/sambuilder.py
+++ b/samwell/sam/sambuilder.py
@@ -452,7 +452,7 @@ class SamBuilder:
 
             default_samtools_opt_list = ["-o", str(path), fp.name]
 
-            if self.sort_order == None:
+            if self.sort_order is None:
                 file_handle.close()
             elif self.sort_order == SamOrder.QueryName:
                 pysam.sort(*(["-n"] + default_samtools_opt_list))

--- a/samwell/sam/sambuilder.py
+++ b/samwell/sam/sambuilder.py
@@ -130,11 +130,11 @@ class SamBuilder:
 
         sort_order = (
             SamOrder.Unsorted
-            if sort_order is None or sort_order == SamOrder.Unknown
+            if sort_order is None
             else sort_order
         )
         assert sort_order in [SamOrder.Coordinate, SamOrder.QueryName, SamOrder.Unsorted], (
-            "`sort_order` must be one of `Coordinate` `QueryName` or `Unsorted`"
+            "`sort_order for `SamBuilder` must be one of `Coordinate` `QueryName` or `Unsorted`"
         )
         self.sort_order: SamOrder = sort_order
 
@@ -453,9 +453,8 @@ class SamBuilder:
 
             default_samtools_opt_list = ["-o", str(path), fp.name]
 
-            if self.sort_order is SamOrder.Unsorted:
-                file_handle.close()
-            elif self.sort_order == SamOrder.QueryName:
+            file_handle.close()
+            if self.sort_order == SamOrder.QueryName:
                 pysam.sort(*(["-n"] + default_samtools_opt_list))
             elif self.sort_order == SamOrder.Coordinate:
                 pysam.sort(*default_samtools_opt_list)

--- a/samwell/sam/sambuilder.py
+++ b/samwell/sam/sambuilder.py
@@ -20,7 +20,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
-from typing import Union
 from typing import IO
 
 import pysam

--- a/samwell/sam/sambuilder.py
+++ b/samwell/sam/sambuilder.py
@@ -452,13 +452,15 @@ class SamBuilder:
 
             default_samtools_opt_list = ["-o", str(path), fp.name]
 
-            if self.sort_order == SamOrder.QueryName:
+            if self.sort_order == None:
+                file_handle.close()
+            elif self.sort_order == SamOrder.QueryName:
                 pysam.sort(*(["-n"] + default_samtools_opt_list))
             elif self.sort_order == SamOrder.Coordinate:
                 pysam.sort(*default_samtools_opt_list)
                 if index:
                     pysam.index(str(path))
-            elif self.sort_order is not None:
+            else:
                 raise ValueError(
                     "SamBuilder sort_order must be one of Coordinate, QueryName, or None"
                 )

--- a/samwell/sam/tests/test_sambuilder.py
+++ b/samwell/sam/tests/test_sambuilder.py
@@ -205,9 +205,10 @@ def make_sort_order_builder(tmpdir: TmpDir, sort_order: SamOrder) -> Path:
     argvalues=[
         (SamOrder.Coordinate, ["test2", "test3", "test4", "test1"]),
         (SamOrder.QueryName, ["test1", "test2", "test3", "test4"]),
+        (SamOrder.Unsorted, ["test3", "test2", "test1", "test4"]),
         (None, ["test3", "test2", "test1", "test4"])
     ],
-    ids=["Coordinate sorting", "Query name sorting", "Unsorted output"]
+    ids=["Coordinate sorting", "Query name sorting", "Unsorted output", "Unsorted output - None"]
 )
 def test_sort_types(
     tmpdir: TmpDir,


### PR DESCRIPTION
Does what it says on the tin. This allows for the passing of an enum value to sambuilder that indicates whether reads should be sorted in query name order, etc.